### PR TITLE
Change the types of some arithmetic operations.

### DIFF
--- a/test/test.jl
+++ b/test/test.jl
@@ -51,9 +51,10 @@ Base.Test.@test 1 + y == 2
 Base.Test.@test y + 1.0 == 2.0
 Base.Test.@test y * 4 == 4
 Base.Test.@test y * 4f0 == 4.0f0
-Base.Test.@test y * 3//4 == 3//4
-Base.Test.@test y / 2 == 0.5
+Base.Test.@test y * 3//4 == year(1)
+Base.Test.@test y / 2 == year(1)
 Base.Test.@test 2 / y == 2
+Base.Test.@test y / y == 1
 Base.Test.@test y*10 % 5 == 0
 Base.Test.@test 5 % y*10 == 0
 Base.Test.@test !(y > 3)


### PR DESCRIPTION
I've been working on plotting Datetime types in Gadfly, and I have the basics working now.

Most of my code is pretty type-generic but makes a few assumptions about the types its plotting. The types in Datetime mostly conform to these assumptions but don't in a few places. I've made some changes here so they do:
- `(/)(x::T, y::T)` results in a plain number if T is a time type. (E.g. `year(100) / year(10) == 10`)
- `(*)(x::T, y::Number)` returns an object of type T (E.g. `10 * year(10) == year(100)`)
- Define `isfinite(::T)` to always return true.

If you don't find these changes offensive, it would make plotting somewhat easier. If you'd rather not, I can still make it work, it will just be a uglier.
