### PR TITLE
Date to DateTime conversion ignores leap seconds

### DIFF
--- a/src/Datetime.jl
+++ b/src/Datetime.jl
@@ -56,10 +56,11 @@ promote_rule{T<:TimeType,R<:Real}(::Type{T},::Type{R}) = R
 convert{T<:TimeType}(::Type{T},x::Real) = convert(T,int64(x))
 convert{R<:Real}(::Type{R}, x::TimeType) = convert(R,int64(x))
 promote_rule{C<:Calendar,T<:Offsets}(::Type{Date{C}},::Type{DateTime{C,T}}) = DateTime{C,T}
-convert{T<:Offsets}(::Type{DateTime{ISOCalendar,T}},x::Date) = convert(DateTime{ISOCalendar,T},86400000*int64(x))
+convert{T<:Offsets}(::Type{DateTime{ISOCalendar,T}},x::Date) = convert(DateTime{ISOCalendar,T}, (secs = 86400000*int64(x); secs - setoffset(T,secs,year(x),0)))
 convert(::Type{Date{ISOCalendar}},x::DateTime) = convert(Date{ISOCalendar},_days(x))
 date(x::DateTime) = convert(Date{CALENDAR},x)
-datetime(x::Date) = convert(DateTime{CALENDAR,OFFSET},x)
+datetime{T<:Offsets}(x::Date, tz::Type{T}=OFFSET) = convert(DateTime{CALENDAR,tz},x)
+datetime(x::Date, tz::String) = datetime(x, timezone(tz))
 #Date type safety
 promote_rule{C<:Calendar,CC<:Calendar}(::Type{Date{C}},::Type{Date{CC}}) = Date{ISOCalendar}
 convert(::Type{Date{ISOCalendar}},x::Date) = convert(Date{ISOCalendar},int64(x))

--- a/test/test.jl
+++ b/test/test.jl
@@ -507,3 +507,9 @@ Base.Test.@test typeof(r.step) == Second{ISOCalendar}
 datetime(int32(2013),int32(10),int32(27),int32(11),int32(10),int32(9))
 datetime(int32(2013),int32(10),int32(27),int32(11),int32(10),int32(9), int32(8), timezone("UTC"))
 
+#Test for date->DateTime conversion w/ leap seconds
+Base.Test.@test date(datetime(date(2012,7,1))) == date(2012,7,1)
+
+#Test for date->DateTime conversion w/ Timezone
+Base.Test.@test datetime(date(2012,7,1),EST) == datetime(2012,7,1,4,0,0,0)
+Base.Test.@test datetime(date(2012,7,1),"America/New_York") == datetime(2012,7,1,4,0,0,0)


### PR DESCRIPTION
The Datetime package convert method for Date -> DateTime ignores leap seconds, leading to the following unexpected behavior:

```
julia> Pkg.status()
1 required packages:
 - Datetime                      0.1.2+             master

julia> date(2012,7,1)
2012-07-01

julia> datetime(date(2012,7,1))
2012-06-30T23:59:36 UTC

julia> date(datetime(date(2012,7,1)))
2012-06-30
```

The problem is the following conversion method:

```
convert{T<:Offsets}(::Type{DateTime{ISOCalendar,T}},x::Date) = convert(DateTime{ISOCalendar,T},86400000*int64(x))
```

After my proposed corrections:

```
julia> date(2012,7,1)
2012-07-01

julia> datetime(date(2012,7,1))
2012-07-01T00:00:00 UTC

julia> date(datetime(date(2012,7,1)))
2012-07-01
```

At the same time, I added support for specifying a non-default timezone, so that a DateTime which is midnight in the specified zone on the specified date is created:

```
julia> datetime(date(2012,7,1), Datetime.Zone389)
2012-07-01T00:00:00 MDT

julia> datetime(date(2012,7,1), MST)
2012-07-01T00:00:00 MDT

julia> datetime(date(2012,7,1), "America/Denver")
2012-07-01T00:00:00 MDT
```

By the way, the issue was missed in test.jl because Date -> DateTime conversion was only tested for using date(1,1,1) which is prior to any leap seconds. I have also added a few appropriate tests at the end of test.jl, because I wasn’t sure exactly where else to best insert them.

Please excuse any improprieties on my part, I am new to Julia, GitHub, and the process of submitting pull requests. Kindly let me know if there's a better way to do it!
